### PR TITLE
fix: fixed rendering long tables

### DIFF
--- a/index.js
+++ b/index.js
@@ -483,7 +483,7 @@ class PDFDocumentWithTables extends PDFDocument {
             this.logg('CRAZY! This a big text on cell');
           } else if(calc > maxY) { // && !lockAddPage
             // lockAddHeader = false;
-            lockAddPage = true;
+            lockAddPage = false;
             onFirePageAdded(); // this.emitter.emit('addPage'); //this.addPage();
             return;
           } 


### PR DESCRIPTION
When a table has many rows and cannot fit the page it should be moved to the next one, but instead it remained on the same page and just reset the Y coordinate, which lead to weird rendering multiple tables one over another.

Before:
<img width="1225" alt="Screenshot 2024-12-18 at 12 00 09" src="https://github.com/user-attachments/assets/fbf08fde-f4b7-4d10-bafa-2a1a27965ccc" />

After:
<img width="1097" alt="Screenshot 2024-12-18 at 12 00 51" src="https://github.com/user-attachments/assets/ec5ac394-146e-4a87-a8bd-838b1e4ec4ef" />
